### PR TITLE
Add README documenting Jekyll build, Netlify deploy, and Netlify CMS setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# openSX70
+
+A photography-focused website for the openSX70 project, built with **Jekyll** on top of a template-based theme and deployed on **Netlify**.
+
+## Tech stack
+
+- **Static site generator:** Jekyll
+- **Templating/layouts:** Jekyll layouts/includes and Sass assets
+- **CMS:** Netlify CMS (`/admin`)
+- **Authentication for CMS:** Netlify Identity + Netlify Git Gateway
+- **Hosting/CI:** Netlify
+
+## Repository structure (high level)
+
+- `_posts/` – blog posts
+- `_tutorials/` – tutorial collection content
+- `_pages/` – custom pages
+- `_layouts/`, `_includes/`, `_sass/` – template/theme structure
+- `admin/` – Netlify CMS app and CMS configuration
+- `_site/` – generated output (build artifact)
+
+## Prerequisites
+
+- Ruby (recommended Ruby 3.x)
+- Bundler
+
+Install dependencies:
+
+```bash
+bundle install
+```
+
+## Local development
+
+Run the local Jekyll server:
+
+```bash
+bundle exec jekyll serve
+```
+
+Then open:
+
+- Website: `http://localhost:4000`
+- CMS (when serving locally): `http://localhost:4000/admin/`
+
+## Production build
+
+Netlify uses the following build command:
+
+```bash
+bundle exec jekyll build
+```
+
+This generates the static site into the `_site/` folder, which is the deploy output published by Netlify.
+
+## CMS and authentication
+
+This project uses **Netlify CMS** for content editing.
+
+- CMS entrypoint: `admin/index.html`
+- CMS configuration: `admin/config.yml`
+- Backend: `git-gateway` (configured in `admin/config.yml`)
+- Login/authentication: **Netlify Identity** (identity widget loaded in `admin/index.html`)
+
+### Typical CMS workflow
+
+1. Sign in at `/admin` using Netlify Identity.
+2. Create or edit content in configured collections (Blog, Tutorials, Pages).
+3. Save and publish changes through Netlify CMS.
+4. Netlify rebuilds and deploys the updated `_site` output.
+
+## Notes
+
+- Site-wide configuration lives in `_config.yml`.
+- Pagination is enabled via `jekyll-paginate`.
+- Uploaded media for CMS is configured under `assets/uploads` (with collection-specific media settings for blog images).


### PR DESCRIPTION
### Motivation

- Provide a concise project-level README that explains the photography site structure, build/deploy process, and CMS/authentication so contributors can run and maintain the site.

### Description

- Add `README.md` describing the tech stack, repository layout, prerequisites, and local development commands including `bundle install` and `bundle exec jekyll serve`.
- Document the production Netlify build command `bundle exec jekyll build` and that Netlify publishes the generated `_site` folder as the deploy output.
- Document Netlify CMS usage and authentication, referencing `admin/index.html` and `admin/config.yml` with the `git-gateway` backend and Netlify Identity login.

### Testing

- Ran `bundle install` to install project dependencies and it completed successfully.
- Ran `bundle exec jekyll build` which completed and produced the `_site` output, with Sass deprecation warnings and duplicate-destination warnings noted but without build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8d1053e483219e61a12558c485a6)