### PR TITLE
Fix navbar visibility when Parts is disabled

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ nav_list:
   FAQ : ['FAQ', '/FAQ', 'fa-question-circle']
   wiki : ['WIKI', 'https://github.com/openSX70/openSX70-Arduino-main/wiki', 'fa-external-link', 'blank']
   Tutorials : ['Tutorials', '/tutorials', 'fa-wrench']
-  Parts : ['Parts', '/shop', 'fa-shopping-cart']
+  Parts : ['Parts', '/shop', 'fa-cogs']
   #Home_Alt_2 : ['Tutorials', '/tutorials', 'fa-wrench']
   Links : ['Links', '/links', 'fa-external-link-square']
   Calculator : ['Serial Calculator', '/calculator', 'fa-calculator']

--- a/_includes/nav-no-js.html
+++ b/_includes/nav-no-js.html
@@ -4,10 +4,9 @@
         <ul>
             {% for page in site.nav_list %}
                 {% assign is_shop_item = page[1][1] == '/shop' %}
-                {% if is_shop_item and site.data.shop.enabled == false %}
-                {% continue %}
-                {% endif %}
+                {% unless is_shop_item and site.data.shop.enabled == false %}
                 <li><i class="fa {{ page[1][2] }}"></i><a href="{{ page[1][1] | prepend: site.baseurl }}">{{ page[1][0] }}</a></li>
+                {% endunless %}
             {% endfor %}
         </ul>
     </div>

--- a/_includes/nav-no-js.html
+++ b/_includes/nav-no-js.html
@@ -3,8 +3,7 @@
     <div class="no-js-menu clearfix">
         <ul>
             {% for page in site.nav_list %}
-                {% assign is_shop_item = page[1][1] == '/shop' %}
-                {% unless is_shop_item and site.data.shop.enabled == false %}
+                {% unless page[1][1] == '/shop' and site.data.shop.enabled == false %}
                 <li><i class="fa {{ page[1][2] }}"></i><a href="{{ page[1][1] | prepend: site.baseurl }}">{{ page[1][0] }}</a></li>
                 {% endunless %}
             {% endfor %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,15 +2,14 @@
     <ul>
         {% for page in site.nav_list %}
             {% assign is_shop_item = page[1][1] == '/shop' %}
-            {% if is_shop_item and site.data.shop.enabled == false %}
-            {% continue %}
-            {% endif %}
+            {% unless is_shop_item and site.data.shop.enabled == false %}
             <li>
             	<i class="fa {{ page[1][2] }}"></i>
             	<a href="{{ page[1][1] | prepend: site.baseurl }}" 
             	{% if page[1][3] == 'blank' %} 
             	target="_blank"
             	{% endif %}>{{ page[1][0] }}</a></li>
+            {% endunless %}
         {% endfor %}
     </ul>
 </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,8 +1,7 @@
 <div id="menu-target">
     <ul>
         {% for page in site.nav_list %}
-            {% assign is_shop_item = page[1][1] == '/shop' %}
-            {% unless is_shop_item and site.data.shop.enabled == false %}
+            {% unless page[1][1] == '/shop' and site.data.shop.enabled == false %}
             <li>
             	<i class="fa {{ page[1][2] }}"></i>
             	<a href="{{ page[1][1] | prepend: site.baseurl }}" 


### PR DESCRIPTION
### Motivation
- Prevent disabling the Parts feature from hiding the entire site navigation and make the Parts link simply omitted when disabled.
- Use a more semantically appropriate icon for the Parts entry instead of a shopping cart.

### Description
- Replace the navigation loop guard in `_includes/nav.html` with an `unless` check so only the `/shop` item is skipped when `site.data.shop.enabled` is `false` and the rest of the nav still renders.
- Apply the same `unless` logic to the no-JS fallback in `_includes/nav-no-js.html` for consistent behavior when JavaScript is disabled.
- Update the Parts icon in `_config.yml` from `fa-shopping-cart` to `fa-cogs` to better match the label.

### Testing
- Ran `bundle install` to install gems and dependencies, which completed successfully.
- Ran `bundle exec jekyll build` to validate the site builds after the changes, and the build completed successfully (project deprecation warnings unrelated to this change were reported but did not cause failure).
- Built site served locally and captured a headless browser screenshot verifying the navbar remains visible and the Parts item is omitted when `_data/shop.yml` has `enabled: false`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb1a365388321a54ed82f6903d0da)